### PR TITLE
pc/bt - add jacoco to pom.xml and get to 100% test coverage

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,12 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
         <version>2.4.3</version>
-        <relativePath/> <!-- lookup parent from repository -->
+        <relativePath /> <!-- lookup parent from repository -->
     </parent>
     <groupId>edu.ucsb.cs156</groupId>
     <artifactId>kitchensink</artifactId>
@@ -83,11 +82,42 @@
 
     <build>
         <plugins>
+
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
             </plugin>
+
+            <!-- Test case coverage report -->
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <version>0.8.6</version>
+                <configuration>
+                    <excludes>
+                        <exclude>**/edu/ucsb/cs156/kitchensink/controllers/FrontendController.*</exclude>
+                        <exclude>**/edu/ucsb/cs156/kitchensink/controllers/FrontendProxyController.*</exclude>
+                        <exclude>**/edu/ucsb/cs156/kitchensink/services/CurrentUserServiceImpl.*</exclude>
+                        <exclude>**/edu/ucsb/cs156/kitchensink/KitchenSinkApplication.*</exclude>
+                    </excludes>
+                </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>prepare-agent</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>report</id>
+                        <phase>prepare-package</phase>
+                        <goals>
+                            <goal>report</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
+
     </build>
 
     <profiles>

--- a/src/test/java/edu/ucsb/cs156/kitchensink/services/CurrentUserServiceTests.java
+++ b/src/test/java/edu/ucsb/cs156/kitchensink/services/CurrentUserServiceTests.java
@@ -1,0 +1,32 @@
+package edu.ucsb.cs156.kitchensink.services;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+
+
+import edu.ucsb.cs156.kitchensink.ControllerTestCase;
+import edu.ucsb.cs156.kitchensink.entities.User;
+
+class CurrentUserServiceTests extends ControllerTestCase {
+
+  
+  @Test
+  void test_isLoggedIn_returns_false() {
+    CurrentUserService currentUserService = mock(CurrentUserService.class);
+    when(currentUserService.get()).thenReturn(null);
+    assertFalse(currentUserService.isLoggedIn());
+  }
+
+  @Test
+  void test_isLoggedIn_returns_true() {
+    CurrentUserService currentUserService = mock(CurrentUserService.class);
+    when(currentUserService.get()).thenReturn(User.builder().build());
+    assertTrue(currentUserService.isLoggedIn());
+  }
+
+}


### PR DESCRIPTION
In this PR, we add support for Java test coverage via jacoco to the pom.xml, and we add a test plus a few exclusions to get us to 100% test coverage.

